### PR TITLE
use refine-extra-args from peano.mm1 in demo.mm1

### DIFF
--- a/examples/demo.mm1
+++ b/examples/demo.mm1
@@ -11,9 +11,8 @@ axiom mp: $ a -> b $ > $ a $ > $ b $;
 do {
   (def (foldl l z s) (if (null? l) z (foldl (tl l) (s z (hd l)) s)))
   (def (verb e) (list ':verb e))
-  (def (refine-extra-args refine p . ps) @
-    foldl ps p @ fn (acc p2) @
-      refine @ list 'mp (verb acc) (verb p2))
+  (def (refine-extra-args refine tgt e . ps)
+   @ refine '{,(foldl ps (verb e) @ fn (acc p2) '(mp ,acc ,p2)) : ,(verb tgt)})
 };
 
 -- theorem a1i (h: $ b $): $ a -> b $ = '(K h);


### PR DESCRIPTION
The previous implementation of `refine-extra-args` fails at the theorem id with the message below, and its signature doesn't seem to match the one outlined in the mm1 document. I just stole the implementation from in peano.mm1 and replaced `ax-mp` with `mp` to get it to work.

```
unknown theorem 'imp'mm0-rs
demo.mm1(25, 1): error occurred here
demo.mm1(12, 52): [fn]
demo.mm1(14, 42): (foldl)
```