### PR TITLE
update mm1 delim docs, extension display name

### DIFF
--- a/mm0-hs/mm1.md
+++ b/mm0-hs/mm1.md
@@ -106,7 +106,9 @@ Notations
     notation-literal ::= prec-constant | identifier
     prec-constant ::= '(' constant ':' precedence-lvl ')'
 
-Notations in MM1 are unchanged from [MM0](../mm0.md#notations).
+MM1 delimiter statements can include either one or two math-strings. If a statement has two math strings, the items in the first are added to the environment as left delimiters, and the items in the second are added as right delimiters. An example of this style can be seen in `/examples/peano.mm1`. If a statement has only one math string, its items are treated as both left and right delimiters, as in `/examples/demo.mm1`.
+
+Beyond that, notations in MM1 are unchanged from [MM0](../mm0.md#notations).
 
 The `input` and `output` commands
 ---

--- a/vscode-mm0/package.json
+++ b/vscode-mm0/package.json
@@ -43,11 +43,11 @@
 		],
 		"configuration": {
 			"type": "object",
-			"title": "Example configuration",
+			"title": "Metamath Zero",
 			"properties": {
 				"metamath-zero.executablePath": {
 					"type": "string",
-					"default": "mm0-hs",
+					"default": "mm0-rs",
 					"description": "Path to the MM0 server."
 				},
 				"metamath-zero.maxNumberOfProblems": {


### PR DESCRIPTION
The mm0 extension currently shows up in VScode's settings menu as "Example Configuration" instead of by name. Also the default executable path still points to mm0-hs, but it looks like cd66408 made mm0-rs the default server.

The doc change reflects the `Delimiter::LeftRight/Delimiter::Both` distinction, which I was confused by before looking at the parser. There's a bit of a discrepancy in that mm0-rs will accept mm0 files with two math-strings of delimiters, but mm0-hs will reject such a file with something like `Error at line 1 column 30: Parse error: TokFormula " ) } , "`, so I may have been wrong in insinuating that this is a change from mm0.

