### PR TITLE
fix mm0-rs doc links; mention dummy in elab_dep_type err

### DIFF
--- a/mm0-rs/src/elab/local_context.rs
+++ b/mm0-rs/src/elab/local_context.rs
@@ -408,6 +408,12 @@ enum InferBinder {
 }
 
 impl Elaborator {
+  /// Elaborate a binder's [DepType] with a given [LocalKind]. Enforces the requirements that (1) 
+  /// bound and dummy variables do not have dependencies, (2) regular variables do not depend
+  /// on dummy variables. The bool in the result's pair indicates whether the variable is a dummy variable.
+  ///
+  /// [DepType]: ../parser/ast/struct.DepType.html 
+  /// [LocalKind]: ../parser/ast/enum.LocalKind.html
   fn elab_dep_type(&mut self, error: &mut bool, lk: LocalKind, d: &DepType) -> Result<(bool, InferSort)> {
     let a = self.env.get_atom(self.ast.span(d.sort));
     let sort = self.data[a].sort.ok_or_else(|| ElabError::new_e(d.sort, "sort not found"))?;
@@ -415,7 +421,7 @@ impl Elaborator {
     Ok(if lk.is_bound() {
       if !d.deps.is_empty() {
         self.report(ElabError::new_e(
-          d.deps[0].start..d.deps.last().unwrap().end, "dependencies not allowed in curly binders"));
+          d.deps[0].start..d.deps.last().unwrap().end, "dependencies not allowed in curly binders or dummy variables"));
         *error = true;
       }
       (lk == LocalKind::Dummy, InferSort::Bound {sort})

--- a/mm0-rs/src/lined_string.rs
+++ b/mm0-rs/src/lined_string.rs
@@ -6,7 +6,7 @@
 //!
 //! [`LinedString::apply_changes`]: struct.LinedString.html#method.apply_changes
 //! [`LinedString`]: struct.LinedString.html
-//! [`Position`]: ../../lsp-types/struct.Position.html
+//! [`Position`]: ../../lsp_types/struct.Position.html
 
 use std::mem;
 use std::ops::{Deref, Index};
@@ -66,7 +66,7 @@ impl LinedString {
 
   /// Turn a character index into an LSP [`Position`]
   ///
-  /// [`Position`]: ../../lsp-types/struct.Position.html
+  /// [`Position`]: ../../lsp_types/struct.Position.html
   pub fn to_pos(&self, idx: usize) -> Position {
     let (pos, line) = match self.lines.binary_search(&idx) {
       Ok(n) => (idx, n+1),
@@ -111,7 +111,7 @@ impl LinedString {
   /// so lines[0] points to the start of line 1, lines[1] points to the start of line 2, etc.
   /// with the start of line 0 just being s.0.
   ///
-  /// [`Position`]: ../../lsp-types/struct.Position.html
+  /// [`Position`]: ../../lsp_types/struct.Position.html
   pub fn to_idx(&self, pos: Position) -> Option<usize> {
     match pos.line.checked_sub(1) {
       None => Some(self.lsp_to_idx(0, pos.character as usize)),
@@ -134,7 +134,7 @@ impl LinedString {
   /// until it reaches some [`Position`]. Return the portion of the passed string slice
   /// that was not added to the LinedString
   ///
-  /// [`Position`]: ../../lsp-types/struct.Position.html
+  /// [`Position`]: ../../lsp_types/struct.Position.html
   pub fn extend_until<'a>(&mut self, unicode: bool, s: &'a str, pos: Position) -> &'a str {
     self.unicode |= unicode;
     let end = self.end();
@@ -171,7 +171,7 @@ impl LinedString {
   /// Does nothing if the LinedString's contents were already less than or equal 
   /// in length to the [`Position`]'s index.
   ///
-  /// [`Position`]: ../../lsp-types/struct.Position.html
+  /// [`Position`]: ../../lsp_types/struct.Position.html
    pub fn truncate(&mut self, pos: Position) {
     if let Some(idx) = self.to_idx(pos) {
       if idx < self.s.len() {
@@ -184,7 +184,7 @@ impl LinedString {
   /// Does a bunch of string juggling to actually realize the contents of an iterator
   /// containing a sequence of [`TextDocumentContentChangeEvent`] messages.
   ///
-  /// [`TextDocumentContentChangeEvent`]: lsp_types/struct.TextDocumentContentChangeEvent.html
+  /// [`TextDocumentContentChangeEvent`]: ../../lsp_types/struct.TextDocumentContentChangeEvent.html
   pub fn apply_changes(&self, changes: impl Iterator<Item=TextDocumentContentChangeEvent>) ->
       (Position, LinedString) {
     let mut old: LinedString;

--- a/mm0-rs/src/parser/ast.rs
+++ b/mm0-rs/src/parser/ast.rs
@@ -117,6 +117,7 @@ pub enum DeclKind { Term, Axiom, Thm, Def }
 pub enum LocalKind { Bound, Reg, Dummy, Anon }
 
 impl LocalKind {
+  /// Return true iff self is a LocalKind::Bound or LocalKind::Dummy
   pub fn is_bound(self) -> bool {
     match self {
       LocalKind::Bound | LocalKind::Dummy => true,

--- a/mm0-rs/src/server.rs
+++ b/mm0-rs/src/server.rs
@@ -1,6 +1,6 @@
 //! Implements the bridge between mm0-rs and an editor via an lsp [`Connection`]
 //!
-//! [`Connection`]: ../../lsp-server/struct.Connection.html
+//! [`Connection`]: ../lsp_server/struct.Connection.html
 
 use std::{fs, io};
 


### PR DESCRIPTION
Some of the links to types in the lsp crates were broken (my fault). 
Also, the error currently shown to the user when `elab_dep_types()`  encounters something like `axiom myAx (x : wff) (.y : wff x): $ x $;` is "dependencies not allowed in curly binders" even though the user may have put the offending dummy variable in regular parens. I just changed it to display "dependencies not allowed in curly binders or dummy variables".