### PR TITLE
fix missing mut in mm0-rs elab

### DIFF
--- a/mm0-rs/src/elab/environment.rs
+++ b/mm0-rs/src/elab/environment.rs
@@ -1032,7 +1032,7 @@ impl Environment {
       refs: Default::default(),
     };
     for (i, d) in other.data.iter().enumerate() {
-      let data = &self.data[lisp_remap.atom[AtomID(i as u32)]];
+      let data = &mut self.data[lisp_remap.atom[AtomID(i as u32)]];
       data.lisp = d.lisp.as_ref().map(|(fs, v)| (fs.clone(), v.remap(lisp_remap)));
       if data.lisp.is_none() {
         data.graveyard = d.graveyard.clone();


### PR DESCRIPTION
You broke it, w2g \s. 

In case this was actually supposed to build as is, here's what I got trying to build ffd40ab with stable rustc 1.45.2 (d3fb005a3 2020-07-31): 
```
error[E0594]: cannot assign to `data.lisp` which is behind a `&` reference
    --> src/elab/environment.rs:1036:7
     |
1035 |       let data = &self.data[lisp_remap.atom[AtomID(i as u32)]];
     |                  --------------------------------------------- help: consider changing this to be a mutable reference: `&mut self.data[lisp_remap.atom[AtomID(i as u32)]]`
1036 |       data.lisp = d.lisp.as_ref().map(|(fs, v)| (fs.clone(), v.remap(lisp_remap)));
     |       ^^^^^^^^^ `data` is a `&` reference, so the data it refers to cannot be written

error[E0594]: cannot assign to `data.graveyard` which is behind a `&` reference
    --> src/elab/environment.rs:1038:9
     |
1035 |       let data = &self.data[lisp_remap.atom[AtomID(i as u32)]];
     |                  --------------------------------------------- help: consider changing this to be a mutable reference: `&mut self.data[lisp_remap.atom[AtomID(i as u32)]]`
...
1038 |         data.graveyard = d.graveyard.clone();
     |         ^^^^^^^^^^^^^^ `data` is a `&` reference, so the data it refers to cannot be written

error: aborting due to 2 previous errors; 5 warnings emitted

For more information about this error, try `rustc --explain E0594`.
error: could not compile `mm0-rs`.
```