### PR TITLE
alleviate early termination of mm0-rs parser

### DIFF
--- a/mm0-rs/src/parser.rs
+++ b/mm0-rs/src/parser.rs
@@ -723,8 +723,12 @@ impl<'a> Parser<'a> {
     }
     match self.modifiers() {
       (m, None) => {
-        if m.is_empty() {Ok(None)}
-        else {self.err_str("expected command keyword")}
+        if m.is_empty() && self.idx == self.source.len() {
+          Ok(None)
+        } else {
+          self.restart_pos = None;
+          self.err_str("expected command keyword")
+        }
       }
       (mut m, Some(id)) => {
         let k = self.span(id);


### PR DESCRIPTION
The following mm1 code:
```
axiom ax_mp (ph ps: wff): $ ph -> ps $ > $ ph $ > $ ps $;

(trouble)

do {
  (display "asdf")
};

```
causes the parser to terminate early after the declaration of `ax_mp`, and as a side effect, will display 0 errors in the output. The interaction is that parser::stmt() returns `Ok(None)` (which is the termination condition for parser::parse()) when it finds a line that (1) isn't an attribute, (2) has no modifiers, and (3) doesn't start with an `ident_start` character, which in this case is the open paren before 'trouble'.
The fix here is just to check whether the parser has reached the end of `self.source` when all three of those conditions are met. If not, try to restart after skipping the first offending group + trailing whitespace. This seems to behave pretty well.

The adjustment to the `None` branch applies the same strategy of skipping one group + whitespace when encountering a bad keyword instead of skipping to the next semicolon. The goal was that if you took the above example and removed the parens around (trouble), the do block would still parse correctly and log its message.
