### PR TITLE
handle platform specific deps/behavior

### DIFF
--- a/mm0-rs/Cargo.toml
+++ b/mm0-rs/Cargo.toml
@@ -33,5 +33,7 @@ lsp-types = "0.80.0"
 lsp-server = "0.3.4"
 annotate-snippets = { version = "0.9.0", features = ["color"] }
 libc = "0.2.76"
-procinfo = "0.4.2"
 deepsize_derive = { path = "components/deepsize_derive" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+procinfo = "0.4.2"

--- a/mm0-rs/src/util.rs
+++ b/mm0-rs/src/util.rs
@@ -268,6 +268,12 @@ fn get_memory_rusage() -> usize {
 
 /// Try to get total memory usage (stack + data) in bytes using the `/proc` filesystem.
 /// Falls back on `getrusage()` if procfs doesn't exist.
+#[cfg(target_os = "linux")]
 pub(crate) fn get_memory_usage() -> usize {
   procinfo::pid::statm_self().map_or_else(|_| get_memory_rusage(), |stat| stat.data * 4096)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn get_memory_usage() -> usize {
+  get_memory_rusage()
 }


### PR DESCRIPTION
rustc 1.46.0 (04488afe3 2020-08-24)
mm0 804e7d0

The dependency `procinfo` causes a compile error (see bottom) on macos and probably all targets that aren't linux based on the crate's documentation. This patch makes procinfo a linux-specific dependency and leaves the behavior on linux machines unchanged while just omitting the memory use info for other targets. I tested it without issues on Catalina 10.15.6 and Ubuntu 18.04. 

```
   Compiling procinfo v0.4.2
error[E0308]: mismatched types
   --> /Users/user/.cargo/registry/src/github.com-1ecc6299db9ec823/procinfo-0.4.2/src/pid/status.rs:189:1
    |
189 | named!(parse_umask<mode_t>,     delimited!(tag!("Umask:\t"),     parse_u32_octal,    line_ending));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u16`, found `u32`
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `procinfo`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```