### PR TITLE
notation must begin with prec-constant

### DIFF
--- a/mm0-rs/src/parser.rs
+++ b/mm0-rs/src/parser.rs
@@ -688,11 +688,17 @@ impl<'a> Parser<'a> {
         let p = self.prec()?;
         self.chr_err(b')')?;
         lits.push(Literal::Const(c, p));
-      } else if let Some(x) = self.ident() {
-        lits.push(Literal::Var(x))
-      } else {return Ok(lits)}
+      } else {
+        match self.ident() {
+          Some(sp) if !lits.is_empty() => { lits.push(Literal::Var(sp)); },
+          Some(sp) => return Err(
+            ParseError::new(sp, "notation declarations must start with a prec-constant; found an ident".into())
+          ),
+          None => return Ok(lits)
+        }
+      }
     }
-  }
+  }  
 
   fn inout_stmt(&mut self, start: usize, m: Modifiers, sp: Span, out: bool) -> Result<Option<Stmt>> {
     if !m.is_empty() {


### PR DESCRIPTION
the notation grammar in mm0.md demands that the first thing after the equals sign in a `gen-notation-stmt` be a `prec-constant`, but the parser currently accepts `gen-notation-stmt` items where the first token after the equals sign is an ident. Something like:
```
notation mul_zero (a: nat) = a ($*0$:10);
```

Apparently this can cause issues when you go to use it later; in trying to make a bootleg postfix declaration, use of this with an infix like `=` caused the math_parser to panic @ 245.

The fix here is just to throw an error if the first token after the equals sign is an ident.