### PR TITLE
doc comments for declarations

### DIFF
--- a/mm0-hs/mm1.md
+++ b/mm0-hs/mm1.md
@@ -16,12 +16,20 @@ As mentioned above, the syntax of MM1 is based on MM0, and the grammar below mak
 
     mm1-file ::= (statement)*
     statement ::= sort-stmt
-               |  decl-stmt                ; This includes MM0's term-stmt,
-                                           ; assert-stmt and def-stmt
+               |  decl-stmt                  ; This includes MM0's term-stmt,
+                                             ; assert-stmt and def-stmt
                |  notation-stmt
                |  inout-stmt
-               |  do-stmt                  ; NEW
-               |  annot-stmt               ; NEW
+               |  do-stmt                    ; NEW
+               |  annot-stmt                 ; NEW
+               |  doc-comment* statement     ; NEW
+
+Doc Comments
+---
+
+    doc-comment ::= '--|' [^\n]* '\n'
+
+Doc comments can be placed above sort-stmt and decl-stmt items; the information displayed when hovering over later uses of the decorated item will include the contents of the doc comment.
 
 Sorts
 ---
@@ -418,7 +426,7 @@ At the beginning of execution, the global context contains a number of primitive
 * `(get! r)` dereferences the ref-cell `r` to get the value.
 * `(set! r v)` sets the value of the ref-cell `r` to `v`.
 * `(async f args)` evaluates `(f args)` on another thread, and returns a procedure that will join on the thread to wait for the result.
-* `(atom-map! [k1 v1] [k2 v2] ...)` creates a new mutable atom map, a key-value store.
+* `(atom-map! '[k1 v1] '[k2 v2] ...)` creates a new mutable atom map, a key-value store.
 * `(atom-map? m)` is true if the argument is an atom map.
 * `(lookup m k)` gets the value stored in the atom map `m` at `k`, or `#undef` if not present. `(lookup m k v)` will return `v` instead if the key is not present, unless `v` is a procedure, in which case it will be called with no arguments on lookup failure.
 * `(insert! m k v)` inserts the value `v` at key `k` in the mutable map `m`, and returns `#undef`. `(insert! m k)` "undefines" the value at key `k` in `m`, that is, it erases whatever is there.

--- a/mm0-rs/src/elab.rs
+++ b/mm0-rs/src/elab.rs
@@ -499,10 +499,10 @@ impl Elaborator {
       &StmtKind::Sort(sp, sd) => {
         let a = self.env.get_atom(self.ast.span(sp));
         let fsp = self.fspan(sp);
-        let id = self.add_sort(a, fsp, span, sd).map_err(|e| e.into_elab_error(sp))?;
+        let id = self.add_sort(a, fsp, span, sd, stmt.doc.clone()).map_err(|e| e.into_elab_error(sp))?;
         self.spans.insert(sp, ObjectKind::Sort(id));
       }
-      StmtKind::Decl(d) => self.elab_decl(span, d)?,
+      StmtKind::Decl(d) => self.elab_decl(span, d, stmt.doc.clone())?,
       StmtKind::Delimiter(Delimiter::Both(f)) => self.pe.add_delimiters(f, f),
       StmtKind::Delimiter(Delimiter::LeftRight(ls, rs)) => self.pe.add_delimiters(ls, rs),
       StmtKind::SimpleNota(n) => self.elab_simple_nota(n)?,

--- a/mm0-rs/src/elab/environment.rs
+++ b/mm0-rs/src/elab/environment.rs
@@ -1127,7 +1127,7 @@ impl<A> AddItemError<A> {
 impl Environment {
   /// Add a sort declaration to the environment. Returns an error if the sort is redeclared,
   /// or if we hit the maximum number of sorts.
-  pub fn add_sort(&mut self, a: AtomID, fsp: FileSpan, full: Span, sd: Modifiers) ->
+  pub fn add_sort(&mut self, a: AtomID, fsp: FileSpan, full: Span, sd: Modifiers, doc: Option<ArcString>) ->
       Result<SortID, AddItemError<SortID>> {
     let new_id = SortID(self.sorts.len().try_into().map_err(|_| AddItemError::Overflow)?);
     let data = &mut self.data[a];
@@ -1143,7 +1143,7 @@ impl Environment {
       }
     } else {
       data.sort = Some(new_id);
-      self.sorts.push(Sort { atom: a, name: data.name.clone(), span: fsp, full, doc: None, mods: sd });
+      self.sorts.push(Sort { atom: a, name: data.name.clone(), span: fsp, full, doc, mods: sd });
       self.stmts.push(StmtTrace::Sort(a));
       Ok(new_id)
     }
@@ -1253,7 +1253,7 @@ impl Environment {
         StmtTrace::Sort(a) => {
           let i = other.data()[a].sort().unwrap();
           let sort = other.sort(i);
-          let id = match self.add_sort(a.remap(remap), sort.span.clone(), sort.full, sort.mods) {
+          let id = match self.add_sort(a.remap(remap), sort.span.clone(), sort.full, sort.mods, sort.doc.clone()) {
             Ok(id) => id,
             Err(AddItemError::Redeclaration(id, r)) => {
               errors.push(ElabError::with_info(sp, r.msg.into(), vec![

--- a/mm0-rs/src/elab/local_context.rs
+++ b/mm0-rs/src/elab/local_context.rs
@@ -653,7 +653,7 @@ impl Elaborator {
   }
 
   /// Elaborate a declaration (`term`, `axiom`, `def`, `theorem`).
-  pub fn elab_decl(&mut self, full: Span, d: &Decl) -> Result<()> {
+  pub fn elab_decl(&mut self, full: Span, d: &Decl, doc: Option<ArcString>) -> Result<()> {
     let mut ehyps = Vec::new();
     let mut error = false;
     macro_rules! report {
@@ -772,7 +772,7 @@ impl Elaborator {
           let t = Term {
             atom, args: args.into(), ret, val,
             span: self.fspan(d.id),
-            doc: None,
+            doc,
             vis: d.mods,
             full,
           };
@@ -861,7 +861,7 @@ impl Elaborator {
         });
         if atom != AtomID::UNDER {
           let t = Thm {
-            atom, span, vis: d.mods, full, doc: None,
+            atom, span, vis: d.mods, full, doc,
             args: args.into(), heap, hyps, ret, proof
           };
           let tid = self.env.add_thm(atom, t.span.clone(), || t).map_err(|e| e.into_elab_error(d.id))?;

--- a/mm0-rs/src/mmu/import.rs
+++ b/mm0-rs/src/mmu/import.rs
@@ -234,7 +234,7 @@ impl<'a> Importer<'a> {
           if let Some(b"free") = next {mods |= Modifiers::FREE;}
           let end = self.close_err()?;
           let a = self.env.get_atom(self.span(x));
-          self.env.add_sort(a, self.fspan(x), (start..end).into(), mods)
+          self.env.add_sort(a, self.fspan(x), (start..end).into(), mods, None)
             .map_err(|e| e.into_elab_error(x))?;
         }
         Some(b"term") => self.decl(start, DeclKind::Term)?,

--- a/mm0-rs/src/parser/ast.rs
+++ b/mm0-rs/src/parser/ast.rs
@@ -18,6 +18,7 @@ use num::BigUint;
 use crate::lined_string::LinedString;
 use crate::util::{Span, ArcString};
 use crate::elab::lisp::print::{EnvDisplay, FormatEnv};
+use crate::elab::environment::DocComment;
 use super::ParseError;
 
 bitflags! {
@@ -657,7 +658,21 @@ pub struct Stmt {
   pub span: Span,
   /// The statement kind and associated data
   pub k: StmtKind,
+  /// The doc comment associated with this statement.
+  pub doc: Option<DocComment>,
 }
+
+impl Stmt {
+  /// Make a new Stmt from a `Span` and `StmtKind`, and an optional `DocComment`
+  ///
+  /// [`Span`]: ../../util/struct.Span.html
+  /// [`StmtKind`]: enum.StmtKind.html
+  /// [`DocComment`]: ../../elab/environment/type.DocComment.html
+  pub fn new(span: Span, k: StmtKind, doc: Option<DocComment>) -> Self {
+    Stmt { span, k, doc }
+  }
+} 
+
 
 /// Contains the actual AST as a sequence of [`Stmt`]s, as well as import, source, and parse info.
 ///


### PR DESCRIPTION
Allows doc comments that are viewable via hover for sort, term, def, axiom, and theorem; the syntax is `--|`, but it's a pretty easy change. If you do decide to change it, you'll need to change both the `doc_comment()` function and the addition to the comment check in `ws()` that makes it not skip over doc comments.

I'm pretty sure the addition to the markdown file is correct in that the parser allows any number of doc comment lines followed by zero or more statements.