### PR TITLE
Add hover docs for `!` and `!!` refine syntax

### DIFF
--- a/mm0-rs/src/elab/environment.rs
+++ b/mm0-rs/src/elab/environment.rs
@@ -12,7 +12,7 @@ use std::hash::Hash;
 use std::collections::HashMap;
 use super::{ElabError, BoxError, spans::Spans, FrozenEnv, FrozenLispVal};
 use crate::util::{ArcString, FileRef, FileSpan, HashMapExt, Span};
-use super::lisp::{LispVal, Syntax};
+use super::lisp::{LispVal, RefineSyntax, Syntax};
 use super::frozen::{FrozenLispKind, FrozenLispRef};
 pub use crate::parser::ast::{Modifiers, Prec};
 
@@ -530,6 +530,8 @@ pub enum ObjectKind {
   Proof(FrozenLispVal),
   /// This is a lisp syntax item; hovering shows the doc comment
   Syntax(Syntax),
+  /// This is a refine tactic syntax item; hovering shows the doc comment
+  RefineSyntax(RefineSyntax),
   /// This is an import; hovering does nothing and go-to-definition goes to the file
   Import(FileRef),
 }

--- a/mm0-rs/src/elab/lisp.rs
+++ b/mm0-rs/src/elab/lisp.rs
@@ -127,6 +127,21 @@ impl std::fmt::Display for Syntax {
   }
 }
 
+str_enum! {
+  /// The `RefineSyntax` type represents atom-like objects that are considered keywords
+  /// in the refine tactic, and have special interpretations.
+  enum RefineSyntax {
+    /// `!`: A modifier on theorem application, for explicitly passing all variables.
+    /// For example `(! foo x y a b p1 p2)` is like `(foo p1 p2)`, except that here
+    /// `x y a b` are the list of all variables, both bound and regular.
+    Explicit: "!",
+    /// `!!`: A modifier on theorem application, for explicitly passing all bound variables.
+    /// For example `(!! foo x y p1 p2)` is like `(foo p1 p2)`, except that here
+    /// `x y` are the list of all bound variables.
+    BoundOnly: "!!",
+  }
+}
+
 /// The type of a metavariable. This encodes the different types of context
 /// in which a term is requested.
 #[derive(Copy, Clone, Debug, EnvDebug)]


### PR DESCRIPTION
This commit adds hover documentation for `!` and `!!` in mm0-rs. Like other syntax documentation, it is controlled by the `SYNTAX_DOCS` constant in server.rs, which is currently disabled. (I assume `SYNTAX_DOCS` was set to false for a reason, so I left it that way.)

Mainly I implemented this because I tried hovering over `!!` to figure out what it did, and was disappointed not to get any information. It was also a way to familiarize myself with the code a little bit. Feel free to reject the patch, since it's disabled anyway.

A small note on the implementation: arguably it would have made more sense to put the `RefineSyntax` enum in refine.rs, but I put it in lisp.rs because it gave easier access to the `str_enum!` macro.

Edit: The failing clippy check seems to be in a function that my patch didn't touch. Also, I *did* run `cargo clippy` before doing the pull request, and didn't get any errors, so I'll try to figure out how to configure clippy the same way that the CI has it configured, to help avoid this issue in the future.

Edit 2: Okay, I switched to using the nightly clippy, and I get the same error on my computer. However, I also get this error on the master branch this way, so I guess nightly updated with a new check sometime in between the most recent commit and this pull request.