### PR TITLE
mm0-rs/README.md: Provide more details

### DIFF
--- a/mm0-hs/mm1.md
+++ b/mm0-hs/mm1.md
@@ -614,3 +614,130 @@ Compilation
 ===
 
 Once a MM1 file is elaborated successfully, the resulting definitions are compiled down to an MM0 file containing all the public theorem statements, and an MMU file containing the proofs. TODO
+
+
+Example
+===
+
+The `examples` directory contains several examples.
+
+Here's a version of demo.mm1, which shows how these can be used.
+
+
+~~~~
+    delimiter $ ( ) ! = , $;
+    provable sort wff;
+    term imp: wff > wff > wff;
+    infixr imp: $->$ prec 2;
+
+    -- The implicational axioms of intuitionistic logic
+    axiom K: $ a -> b -> a $;
+    axiom S: $ (a -> b -> c) -> (a -> b) -> (a -> c) $;
+    axiom mp: $ a -> b $ > $ a $ > $ b $;
+
+    -- Some basic metafunctions borrowed from peano.mm1
+    do {
+      (def (foldl l z s) (if (null? l) z (foldl (tl l) (s z (hd l)) s)))
+      (def (refine-extra-args refine tgt e . ps)
+        (refine tgt (foldl ps '(:verb ,e) @ fn (acc p2) '(mp ,acc ,p2))))
+    };
+
+    theorem a1i (h: $ b $): $ a -> b $ = '(K h);
+    theorem mpd (h1: $ a -> b $) (h2: $ a -> b -> c $): $ a -> c $ = '(S h2 h1);
+    theorem mpi (h1: $ b $) (h2: $ a -> b -> c $): $ a -> c $ =
+                '(mpd (a1i h1) h2);
+    theorem id: $ a -> a $ = '(mpd (! K _ a) K);
+
+    theorem id2: $ a -> a $ =
+    '(S K (! K _ a));
+
+    do {
+      (def mvar-sort @ match-fn @ (mvar s _) s)
+      (def (named e)
+        (refine e)
+        (map (fn (v) (set! v @ dummy! (mvar-sort v))) (get-mvars)))
+    };
+
+    theorem id3: $ a -> a $ =
+    (named '(S K K));
+
+    sort nat;
+    term all {x: nat} (P: wff x): wff;
+    notation all (x P) = ($!$:4) x P;
+    term eq (a b: nat): wff;
+    infixl eq: $=$ prec 10;
+
+    axiom refl: $ a = a $;
+    axiom symm: $ a = b $ > $ b = a $;
+    axiom trans: $ a = b $ > $ b = c $ > $ a = c $;
+
+    do {
+      {2 + 2}
+    };
+
+    axiom foo (P Q: wff x): $ !x (P -> Q) -> !x P -> !x Q $;
+
+    term _0: nat; prefix _0: $0$ prec max;
+    term succ: nat > nat;
+    axiom succ_eq: $ a = b $ > $ succ a = succ b $;
+
+    def _1 = $ succ 0 $; prefix _1: $1$ prec max;
+    def _2 = $ succ 1 $; prefix _2: $2$ prec max;
+    def _3 = $ succ 2 $; prefix _3: $3$ prec max;
+    def _4 = $ succ 3 $; prefix _4: $4$ prec max;
+
+    term add (a b: nat): nat;
+    infixl add: $+$ prec 20;
+    axiom add_eq: $ a = b $ > $ c = d $ > $ a + c = b + d $;
+
+    axiom add_succ: $ a + succ b = succ (a + b) $;
+    axiom add_zero: $ a + 0 = a $;
+
+    theorem two_plus_two_is_four: $ 2 + 2 = 4 $ =
+    (focus
+      'trans
+      'add_succ
+      'succ_eq
+      'trans
+      'add_succ
+      'succ_eq
+      'add_zero
+    (stat));
+
+    theorem two_plus_two_is_four_ALT: $ 2 + 2 = 4 $ =
+    (focus
+      '(trans add_succ succ_eq)
+      '(trans add_succ succ_eq)
+      'add_zero
+    (stat));
+
+    theorem two_plus_two_is_four_ALT2: $ 2 + 2 = 4 $ =
+    '(trans add_succ @ succ_eq @
+      trans add_succ @ succ_eq @
+
+      add_zero);
+~~~~
+
+
+Note that a proof looks like `theorem NAME: $ ... expression... $ =`
+followed by an s-expression-like proof.
+"(stat)" prints the current proof state.
+
+There aren't too many fancy tactics right now unless you write them
+yourself (in the manner of `norm_num`). If you want to keep moving
+up the hierarchy of complexity, you can try to follow the first few
+proofs in `peano.mm1` (after the big do block, starting at theorem
+a1i). It takes quite a while before the
+proofs start getting complicated enough to need tactic mode (search
+for "focus"), although the "named" tactic is used in lots of simpler
+theorems to wrap a proof script to name dummy variables.
+
+To create a disconnected step, you can use `have` in the form
+`(have 'NAME $ EXPRESSION $ _)` and the _ will give you EXPRESSION
+as the goal, which need not have anything to do with
+what the current theorem is. You can use NAME to refer to the step later.
+
+If you want to say "unify the goal with this expression" you
+can use `{_ : $ EXPRESSION $}` and the _ will unify the goal against
+EXPRESSION, which you can obtain by copy-pasting from the goal and
+making modifications.

--- a/mm0-rs/README.md
+++ b/mm0-rs/README.md
@@ -31,7 +31,7 @@ Select View/Extensions, search for "Metamath"
 Look for "Metamath Zero" & press its "install" button.
 
 If `mm0-rs` is not on your path, then you need to
-change the Visual Studio Code settings so it can execute `mm0-rss`.
+change the Visual Studio Code settings so it can execute `mm0-rs`.
 To do this, after you've installed "Metamath Zero" look at the name,
 click on its small "gear symbol" to change its settings.
 Note: if you click on its "gear symbol" and see nothing, that's a bug

--- a/mm0-rs/README.md
+++ b/mm0-rs/README.md
@@ -6,19 +6,79 @@ Watch this space for more updates, as `mm0-rs` is under active development. See 
 
 ## Compilation
 
-To compile `mm0-rs`, run
+To compile `mm0-rs`, first install Rust.
+You then need to download this repository (e.g.,
+`git clone https://github.com/digama0/mm0.git`).
+Then cd into this `mm0-rs` directory (using `cd mm0/mm0-rs`) and run:
 
     cargo build --release
 
-from the `mm0-rs` directory, then copy or symlink the resulting executable file `target/release/mm0-rs` to your system path and/or point `vscode-mm0` to it using the setting
-
-    "metamath-zero.executablePath": "mm0-rs",
-
+You then should make it easy to execute.
+One way is to copy or symlink the resulting executable file `target/release/mm0-rs` to your system path.
+An alternative, if you're integrating with Visual Studio Code as suggested
+below, is to point `vscode-mm0` to the executable using (as
+explained below) the setting "metamath-zero.executablePath": "mm0-rs"
 in your `settings.json` file.
+
+## Integration with Visual Studio Code
+
+We typically use Visual Studio Code, an open source software
+editor / IDE which supports LSP servers.
+If you choose to do the same,
+[download and install Visual Studio Code](https://code.visualstudio.com/).
+
+Select View/Extensions, search for "Metamath"
+Look for "Metamath Zero" & press its "install" button.
+
+If `mm0-rs` is not on your path, then you need to
+change the Visual Studio Code settings so it can execute `mm0-rss`.
+To do this, after you've installed "Metamath Zero" look at the name,
+click on its small "gear symbol" to change its settings.
+Note: if you click on its "gear symbol" and see nothing, that's a bug
+in the Visual Studio Code program; restart it and again select View/Extensions
+to you can see the settings to change them.
+Now modify the Metamath-zero" Executable Path metamath-zero.executablePath
+to be the correct path for the executable
+(it defaults to `mm0-rs`).
+You should probably use an absolute path (e.g., one starting with "/"
+on Linux/Unix/MacOS).
 
 ## Usage
 
-* `mm0-rs server` causes it to send and receive LSP server commands via stdin and stdout. This is not used directly from the CLI but rather is invoked by `vscode-mm0` when it is set up to use `mm0-rs` as a language server.
-  * `mm0-rs server --debug` is run by `vscode-mm0` when the extension itself is run in debugging mode, and this will enable backtraces and logging.
+The `mm0-rs` program provides a number of modes and options if you
+want to invoke it directly. For example:
 
+* `mm0-rs server` causes it to send and receive LSP server commands via stdin and stdout. This is not used directly from the CLI but rather is invoked by `vscode-mm0` when it is set up to use `mm0-rs` as a language server.
+* `mm0-rs server --debug` is run by `vscode-mm0` when the extension itself is run in debugging mode, and this will enable backtraces and logging.
 * `mm0-rs compile foo.mm1` will compile an MM1 file, reporting errors to the console. This is essentially the console version of the `server` mode.
+
+You can easily use `mm0-rs` from within Visual Studio Code.
+Start Visual Studio Code, then use File/Open,
+and navigate to the mm0/examples directory.
+Select a file to look at; `do-block.mm1` and `demo.mm1`
+are good starting points.
+Select "View/Problems" to see a summary.
+
+File `demo.mm1` show what proofs look like in MM1.
+A theorem proof looks like `theorem NAME: $ ... expression... $ =`
+followed by an s-expression-like proof.
+"(stat)" prints the current proof state.
+
+There aren't too many fancy tactics right now unless you write them
+yourself (in the manner of `norm_num`). If you want to keep moving
+up the hierarchy of complexity, you can try to follow the first few
+proofs in peano.mm1 (after the big do block, starting at theorem
+a1i). It takes quite a while before the
+proofs start getting complicated enough to need tactic mode (search
+for "focus"), although the "named" tactic is used in lots of simpler
+theorems to wrap a proof script to name dummy variables.
+
+To create a disconnected step, you can use `have` in the form
+`(have 'NAME $ EXPRESSION $ _)` and the _ will give you EXPRESSION
+as the goal, which need not have anything to do with
+what the current theorem is. You can use NAME to refer to the step later.
+
+If you want to say "unify the goal with this expression" you
+can use `{_ : $ EXPRESSION $}` and the _ will unify the goal against
+EXPRESSION, which you can obtain by copy-pasting from the goal and
+making modifications.

--- a/mm0-rs/README.md
+++ b/mm0-rs/README.md
@@ -17,7 +17,7 @@ You then should make it easy to execute.
 One way is to copy or symlink the resulting executable file `target/release/mm0-rs` to your system path.
 An alternative, if you're integrating with Visual Studio Code as suggested
 below, is to point `vscode-mm0` to the executable using (as
-explained below) the setting "metamath-zero.executablePath": "mm0-rs"
+explained below) the setting `"metamath-zero.executablePath": "mm0-rs"`
 in your `settings.json` file.
 
 ## Integration with Visual Studio Code

--- a/mm0-rs/README.md
+++ b/mm0-rs/README.md
@@ -27,8 +27,14 @@ editor / IDE which supports LSP servers.
 If you choose to do the same,
 [download and install Visual Studio Code](https://code.visualstudio.com/).
 
-Select View/Extensions, search for "Metamath"
-Look for "Metamath Zero" & press its "install" button.
+Next, install the "Metamath Zero" language support extension.
+You can do this one of two ways:
+1. Use Quick Open (Ctrl-P on Windows/Linux, Cmd-P on MacOS)),
+   paste `ext install digama0.metamath-zero` in the box and hit Enter (Return).
+   This will install the ["Metamath Zero" language support](https://marketplace.visualstudio.com/items?itemName=digama0.metamath-zero) extension.
+2. Select View/Extensions, search for "Metamath"
+  Look for "Metamath Zero"; make sure it's the correct one
+  (digama0.metamath-zero). If so, press its "install" button.
 
 If `mm0-rs` is not on your path, then you need to
 change the Visual Studio Code settings so it can execute `mm0-rs`.
@@ -57,29 +63,10 @@ You can easily use `mm0-rs` from within Visual Studio Code.
 Start Visual Studio Code, then use File/Open,
 and navigate to the mm0/examples directory.
 Select a file to look at; `do-block.mm1` and `demo.mm1`
-are good starting points.
+are good starting points
+(`demo.mm1` shows what proofs look like in MM1).
 Select "View/Problems" to see a summary.
 
-File `demo.mm1` show what proofs look like in MM1.
-A theorem proof looks like `theorem NAME: $ ... expression... $ =`
-followed by an s-expression-like proof.
-"(stat)" prints the current proof state.
-
-There aren't too many fancy tactics right now unless you write them
-yourself (in the manner of `norm_num`). If you want to keep moving
-up the hierarchy of complexity, you can try to follow the first few
-proofs in peano.mm1 (after the big do block, starting at theorem
-a1i). It takes quite a while before the
-proofs start getting complicated enough to need tactic mode (search
-for "focus"), although the "named" tactic is used in lots of simpler
-theorems to wrap a proof script to name dummy variables.
-
-To create a disconnected step, you can use `have` in the form
-`(have 'NAME $ EXPRESSION $ _)` and the _ will give you EXPRESSION
-as the goal, which need not have anything to do with
-what the current theorem is. You can use NAME to refer to the step later.
-
-If you want to say "unify the goal with this expression" you
-can use `{_ : $ EXPRESSION $}` and the _ will unify the goal against
-EXPRESSION, which you can obtain by copy-pasting from the goal and
-making modifications.
+For more about how to use MM1 to create proofs, see file `../mm0-hs/mm1.md`
+(the mm0-hs tool is deprecated, but the MM1 documentation is currently
+still there).

--- a/mm0-rs/README.md
+++ b/mm0-rs/README.md
@@ -6,7 +6,7 @@ Watch this space for more updates, as `mm0-rs` is under active development. See 
 
 ## Compilation
 
-To compile `mm0-rs`, first install Rust.
+To compile `mm0-rs`, first [install Rust](https://rustup.rs/).
 You then need to download this repository (e.g.,
 `git clone https://github.com/digama0/mm0.git`).
 Then cd into this `mm0-rs` directory (using `cd mm0/mm0-rs`) and run:

--- a/mm0-rs/README.md
+++ b/mm0-rs/README.md
@@ -37,7 +37,8 @@ click on its small "gear symbol" to change its settings.
 Note: if you click on its "gear symbol" and see nothing, that's a bug
 in the Visual Studio Code program; restart it and again select View/Extensions
 to you can see the settings to change them.
-Now modify the Metamath-zero" Executable Path metamath-zero.executablePath
+Now modify the "Metamath-zero Executable Path" setting (which corresponds
+to `metamath-zero.executablePath` in `settings.json`)
 to be the correct path for the executable
 (it defaults to `mm0-rs`).
 You should probably use an absolute path (e.g., one starting with "/"


### PR DESCRIPTION
Provide more step-by-step instructions on how to install and run
mm0-rs, and provide more hints about how to use the prover.

This needs *much* more information on how to create a proof, but
having *some* information is better than none.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>