### PR TITLE
Add hover documentation for some builtin callbacks

### DIFF
--- a/mm0-rs/src/elab/environment.rs
+++ b/mm0-rs/src/elab/environment.rs
@@ -12,7 +12,7 @@ use std::hash::Hash;
 use std::collections::HashMap;
 use super::{ElabError, BoxError, spans::Spans, FrozenEnv, FrozenLispVal};
 use crate::util::{ArcString, FileRef, FileSpan, HashMapExt, Span};
-use super::lisp::{LispVal, RefineSyntax, Syntax};
+use super::lisp::{LispVal, BuiltinCallback, RefineSyntax, Syntax};
 use super::frozen::{FrozenLispKind, FrozenLispRef};
 pub use crate::parser::ast::{Modifiers, Prec};
 
@@ -536,6 +536,8 @@ pub enum ObjectKind {
   Syntax(Syntax),
   /// This is a refine tactic syntax item; hovering shows the doc comment
   RefineSyntax(RefineSyntax),
+  /// This is a syntax item for definitions of builtin callback functions, such as `refine-extra-args`.
+  BuiltinCallback(BuiltinCallback),
   /// This is an import; hovering does nothing and go-to-definition goes to the file
   Import(FileRef),
 }

--- a/mm0-rs/src/elab/lisp.rs
+++ b/mm0-rs/src/elab/lisp.rs
@@ -174,6 +174,33 @@ str_enum! {
   }
 }
 
+str_enum! {
+  /// The `BuiltinCallback` type represents the atoms for callback functions
+  /// that are hardcoded into the interpreter.
+  enum BuiltinCallback {
+    /// The `annotate` function is a callback used to define what happens when an annotation like
+    /// `@foo def bar = ...` is used. Calling it directly results in an error.
+    Annotate: "annotate",
+    /// The `refine-extra-args` function is a callback used when an application in refine
+    /// uses too many arguments. Calling it directly results in an error.
+    RefineExtraArgs: "refine-extra-args",
+    /// `to-expr-fallback` is called when elaborating a term that is not otherwise recognized.
+    /// Calling it directly results in an error.
+    ToExprFallback: "to-expr-fallback",
+  }
+}
+
+impl BuiltinCallback {
+  /// Converts this `BuiltinCallback` to the corresponding `AtomID`.
+  #[must_use] pub fn atom_id(self) -> AtomID {
+    match self {
+      BuiltinCallback::Annotate => AtomID::ANNOTATE,
+      BuiltinCallback::RefineExtraArgs => AtomID::REFINE_EXTRA_ARGS,
+      BuiltinCallback::ToExprFallback => AtomID::TO_EXPR_FALLBACK,
+    }
+  }
+}
+
 /// The type of a metavariable. This encodes the different types of context
 /// in which a term is requested.
 #[derive(Copy, Clone, Debug, EnvDebug)]

--- a/mm0-rs/src/elab/lisp/parser.rs
+++ b/mm0-rs/src/elab/lisp/parser.rs
@@ -11,7 +11,7 @@ use crate::parser::ast::{SExpr, SExprKind, Atom};
 use crate::util::{ArcString, OptionExt};
 use super::super::{AtomID, Span, DocComment, Elaborator, ElabError, ObjectKind};
 use super::{BuiltinProc, FileSpan, LispKind, LispVal, Proc, ProcSpec,
-  Remap, Remapper, Syntax};
+  Remap, Remapper, BuiltinCallback, Syntax};
 use super::super::math_parser::{QExpr, QExprKind};
 use super::print::{FormatEnv, EnvDisplay};
 
@@ -492,7 +492,16 @@ impl<'a> LispParser<'a> {
     let (sp, x, stack) = self.def_var(e)?;
     let ir = self.def_ir(sp, es, stack)?;
     if self.ctx.len() == 0 {
-      self.spans.insert(sp, ObjectKind::Global(x));
+      match x {
+        AtomID::ANNOTATE =>
+        {self.spans.insert(sp, ObjectKind::BuiltinCallback(BuiltinCallback::Annotate));}
+        AtomID::REFINE_EXTRA_ARGS =>
+        {self.spans.insert(sp, ObjectKind::BuiltinCallback(BuiltinCallback::RefineExtraArgs));}
+        AtomID::TO_EXPR_FALLBACK =>
+        {self.spans.insert(sp, ObjectKind::BuiltinCallback(BuiltinCallback::ToExprFallback));}
+        _ =>
+        {self.spans.insert(sp, ObjectKind::Global(x));}
+      }
     }
     Ok((sp, x, ir))
   }

--- a/mm0-rs/src/server.rs
+++ b/mm0-rs/src/server.rs
@@ -750,6 +750,10 @@ async fn hover(path: FileRef, pos: Position) -> StdResult<Option<Hover>, Respons
           ((sp, mk_doc(stx.doc())), None)
         } else { return None }
       }
+      ObjectKind::BuiltinCallback(stx) => {
+        let ld = env.data[stx.atom_id()].lisp.as_ref()?;
+        ((sp, mk_doc(stx.doc())), ld.doc.clone())
+      }
       &ObjectKind::Global(a) => {
         let ld = env.data[a].lisp.as_ref()?;
         if let Some(doc) = &ld.doc {
@@ -823,7 +827,8 @@ async fn definition<T>(path: FileRef, pos: Position,
       &ObjectKind::Thm(t) => res.push(thm(t)),
       ObjectKind::Var(_) |
       ObjectKind::Syntax(_) |
-      ObjectKind::RefineSyntax(_) => {}
+      ObjectKind::RefineSyntax(_) |
+      ObjectKind::BuiltinCallback(_) => {}
       ObjectKind::Expr(e) => {
         let head = e.uncons().next().unwrap_or(e);
         if let Some(DeclKey::Term(t)) = head.as_atom().and_then(|a| env.data()[a].decl()) {
@@ -1079,7 +1084,8 @@ async fn references<T>(
     }
     ObjectKind::Import(_) |
     ObjectKind::Syntax(_) |
-    ObjectKind::RefineSyntax(_) => None,
+    ObjectKind::RefineSyntax(_) |
+    ObjectKind::BuiltinCallback(_) => None,
     ObjectKind::Var(a) => Some(Key::Var(a)),
     ObjectKind::Sort(a) => Some(Key::Sort(a)),
     ObjectKind::Term(a, _) => Some(Key::Term(a)),


### PR DESCRIPTION
These are `annotate`, `refine-extra-args`, and `to-expr-fallback`.

I didn't gate this behind the syntax_docs setting, maybe I should have.