### PR TITLE
annotate binders, light doc styling

### DIFF
--- a/mm0-rs/src/doc/mod.rs
+++ b/mm0-rs/src/doc/mod.rs
@@ -60,9 +60,19 @@ impl<'a, 'b, W: Write> pretty::RenderAnnotated<'b, Annot> for HtmlPrinter<'a, W>
       Annot::SortModifiers(_) => tag!(span "sortmod"),
       Annot::Visibility(_) => tag!(span "vis"),
       Annot::Keyword => tag!(span "kw"),
-      Annot::SortName(_) => tag!(span "sort"),
+      Annot::SortName(sid) => {
+        write!(self.w.0, "<a class=\"sortname\" href=\"{}index.html#", self.rel)?;
+        let ad = &self.env.data[self.env.sorts[sid].atom];
+        disambiguated_anchor(&mut self.w.0, ad, false)?;
+        write!(self.w.0, "\">")?;
+        self.stack.push("a");
+      }
       Annot::TermName(tid) => {
-        write!(self.w.0, "<a class=\"term\" href=\"{}index.html#", self.rel)?;
+        let kind = match &self.env.terms[tid].kind {
+          crate::elab::environment::TermKind::Term => "term",
+          crate::elab::environment::TermKind::Def(_) => "def"
+        };
+        write!(self.w.0, "<a class=\"{}\" href=\"{}index.html#", kind, self.rel)?;
         let ad = &self.env.data[self.env.terms[tid].atom];
         disambiguated_anchor(&mut self.w.0, ad, false)?;
         write!(self.w.0, "\">")?;
@@ -71,8 +81,12 @@ impl<'a, 'b, W: Write> pretty::RenderAnnotated<'b, Annot> for HtmlPrinter<'a, W>
       Annot::ThmName(tid) => {
         let w = &mut *self.w.0;
         let rel = self.rel;
+        let kind = match &self.env.thms[tid].kind {
+          ThmKind::Axiom => "ax",
+          ThmKind::Thm(_) => "thm"
+        };
         self.mangler.mangle(self.env, tid, |_, mangled|
-          write!(w, r#"<a class="thm" href="{}thms/{}.html">"#, rel, mangled))?;
+          write!(w, r#"<a class="{}" href="{}thms/{}.html">"#, kind, rel, mangled))?;
         self.stack.push("a");
       }
     }

--- a/mm0-rs/src/doc/stylesheet.css
+++ b/mm0-rs/src/doc/stylesheet.css
@@ -106,7 +106,7 @@ h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
 body {
     font-family: "Nobile", sans-serif;
     font-size: 100%;
-    background-color: #eee;
+    background-color: #f5f7ff;
     margin: 0;
     padding: 0;
 }
@@ -131,6 +131,12 @@ a, a .pre {
     color: #1b61d6;
     text-decoration: none;
 }
+
+a.sort:link, a.sortname:link, span.sort {color:#c08b30;}
+a.ax:link {color:#c94922;}
+a.def:link {color: #22a2c9;}
+a.thm:link { color: #6679cc; }
+a.term:link {color: #9c637a;}
 
 a:hover, a:hover .pre {
     text-decoration: underline;
@@ -177,7 +183,7 @@ div.body p, div.body dd, div.body li {
 pre {
     padding: 10px;
     background-color: #fafafa;
-    color: #222;
+    color: #545b78;
     line-height: 1.2em;
     border: 2px solid #C6C9CB;
     margin: 1.5em 0 1.5em 0;
@@ -253,8 +259,8 @@ table.proof pre {
 }
 
 code {
-    background-color: transparent;
-    color: #222;
+    background-color: #f0f3ff;
+    color: #545b78;
     font-family: Fira Code,Consolas,Monaco,'Andale Mono','Ubuntu Mono',monospace;
     font-size: 1em;
 }

--- a/mm0-rs/src/elab/lisp/pretty.rs
+++ b/mm0-rs/src/elab/lisp/pretty.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 use std::cell::RefCell;
-use std::{mem, fmt::{self, Write}};
+use std::{mem, fmt::{self}};
 use std::borrow::Cow;
 use pretty::DocAllocator;
 use itertools::Itertools;
@@ -373,13 +373,16 @@ impl<'a> Pretty<'a> {
     })
   }
 
-  fn dep_type(bvars: &[AtomID], ds: u64, fe: FormatEnv<'_>, f: &mut impl fmt::Write) -> fmt::Result {
+  fn dep_type(&'a self, bvars: &[AtomID], ds: u64, mut doc: RefDoc<'a>) -> RefDoc<'a> {
     let mut i = 1;
     for x in bvars {
-      if ds & i != 0 {write!(f, " {}", fe.to(x))?}
+      if ds & i != 0 {
+        let rhs = Doc::text(format!(" {}", self.fe.to(x)));
+        doc = self.append_doc(doc, self.alloc(rhs));
+      }
       i *= 2;
     }
-    Ok(())
+    doc
   }
 
   fn grouped_binders(&'a self, mut doc: RefDoc<'a>,
@@ -392,24 +395,47 @@ impl<'a> Pretty<'a> {
         Some((_, ty)) => ty,
       };
       let (bis1, bis2) = rest.split_at(it.position(|(_, ty2)| ty != ty2).map_or(rest.len(), |x| x + 1));
-      let mut buf = String::new();
+      let mut buf = Self::nil();
       match *ty {
         Type::Bound(s) => {
-          write!(buf, "{{{}: {}}}", bis1.iter().map(|(a, _)| {
+          buf = self.append_doc(buf, self.alloc(Doc::text("{")));
+          let lhs = format!("{}", bis1.iter().map(|(a, _)| {
             bvars.push(a.unwrap_or(AtomID::UNDER));
             self.fe.to(a)
-          }).format(" "), self.fe.to(&s)).expect("writing to a String");
+          }).format(" "));
+          buf = self.append_doc(buf, self.alloc(Doc::text(lhs)));
+          buf = self.append_doc(buf, self.alloc(Doc::text(": ")));
+
+          buf = self.append_doc(
+            buf, 
+            self.annot(
+              Annot::SortName(s),
+              self.alloc(Doc::text(self.fe.env.sorts[s].name.to_string()))
+            )
+          );
+          buf = self.append_doc(buf, self.alloc(Doc::text("}")));
         }
         Type::Reg(s, ds) => {
-          write!(buf, "({}: {}",
-            bis1.iter().map(|(a, _)| self.fe.to(a)).format(" "),
-            self.fe.to(&s)).expect("writing to a String");
-          Self::dep_type(bvars, ds, self.fe, &mut buf).expect("writing to a Vec");
-          write!(buf, ")").expect("writing to a String");
+          buf = self.append_doc(buf, self.alloc(Doc::text("(")));
+          let lhs = format!("{}", bis1.iter().map(|(a, _)| {
+            bvars.push(a.unwrap_or(AtomID::UNDER));
+            self.fe.to(a)
+          }).format(" "));
+          buf = self.append_doc(buf, self.alloc(Doc::text(lhs)));
+          buf = self.append_doc(buf, self.alloc(Doc::text(": ")));
+          buf = self.append_doc(
+            buf, 
+            self.annot(
+              Annot::SortName(s),
+              self.alloc(Doc::text(self.fe.env.sorts[s].name.to_string()))
+            )
+          );
+
+          buf = self.dep_type(bvars, ds, buf);
+          buf = self.append_doc(buf, self.alloc(Doc::text(")")));
         }
       }
-      doc = self.append_doc(doc, self.append_doc(Self::softline(),
-        self.alloc(Doc::text(buf))));
+      doc = self.append_doc(doc, self.append_doc(Self::softline(), buf));
       rest = bis2;
     }
   }
@@ -431,12 +457,14 @@ impl<'a> Pretty<'a> {
     let doc = self.grouped_binders(doc, &t.args, &mut bvars);
     let doc = self.append_doc(doc, self.alloc(Doc::text(":")));
     let doc = self.alloc(Doc::Group(doc));
-    let mut buf = format!("{}", self.fe.to(&t.ret.0));
-    Self::dep_type(&bvars, t.ret.1, self.fe, &mut buf).expect("writing to a String");
+    let mut buf = self.annot(
+      Annot::SortName(t.ret.0), 
+      self.alloc(Doc::text(self.fe.env.sorts[t.ret.0].name.to_string()))
+    );
+    buf = self.dep_type(&bvars, t.ret.1, buf);
     if let (true, TermKind::Def(Some(expr))) = (show_def, &t.kind) {
-      buf += " =";
-      let doc = self.append_doc(doc, self.append_doc(Self::softline(),
-        self.alloc(Doc::text(buf))));
+      buf = self.append_doc(buf, self.alloc(Doc::text(" =")));
+      let doc = self.append_doc(doc, self.append_doc(Self::softline(), buf));
       let mut bvars = Vec::new();
       let mut heap = Vec::new();
       self.fe.binders(&t.args, &mut heap, &mut bvars);
@@ -449,9 +477,8 @@ impl<'a> Pretty<'a> {
         self.expr_delimited(val, "$ ", " $;")));
       self.alloc(Doc::Group(doc))
     } else {
-      buf += ";";
-      self.append_doc(doc, self.append_doc(Self::softline(),
-        self.alloc(Doc::text(buf))))
+      buf = self.append_doc(buf, self.alloc(Doc::text(";")));
+      self.append_doc(doc, self.append_doc(Self::softline(), buf))
     }
   }
 


### PR DESCRIPTION
+ gives a different class to term v. def and axiom v. theorem,
+ changes the pretty printer implementation so that it annotates variables in binders with their sort info
+ sort names are  now an intra-doc links
+ applies some basic styling so you get an idea of how any given palette will compose. The colors are based on [this palette](https://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool/)