### PR TITLE
Reject zero-length proofs in mm0-rs::mmb::parser.

### DIFF
--- a/mm0-rs/src/mmb/parser.rs
+++ b/mm0-rs/src/mmb/parser.rs
@@ -325,6 +325,9 @@ impl Arg {
 fn try_next_decl(buf: &[u8], n: usize) -> Option<Option<(StmtCmd, ProofIter<'_>, usize)>> {
   let bytes = buf.get(n..)?;
   let (cmd, data, next) = parse_cmd(bytes)?;
+  if data == 0 {
+    return None
+  }
   if cmd == 0 {return Some(None)}
   let stmt = cmd.try_into().ok()?;
   let next2 = n + u32_as_usize(data);


### PR DESCRIPTION
I hooked a fuzzer up to the main `MmbFile::parse()` method in the WIP
mmb parser library and found a fun one; if the `parse_cmd` call in
`try_next_decl` returns a cmd/data pair pair of `(_, n)` where `n`
parses as a 0, `next2` will be equal to the original starting
point `n`. The parser doesn't get advanced, so it enters an infinite loop.

As of e279e87 you can trigger this from the main `MmbFile::parse()` method
with the following mmb file:
```
[77, 77, 48, 66, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 43, 0, 0, 0, 0, 0, 248, 255, 47, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 6, 255, 0, 0, 0, 255, 255, 255, 255, 0, 0, 255]
```