### PR TITLE
mmb doc fix

### DIFF
--- a/mm0-c/mmb.md
+++ b/mm0-c/mmb.md
@@ -42,7 +42,7 @@ The file header contains basic information about the format and pointers to the 
 | `num_terms` | `u32`                        | The number of `term` and `def` in the file.         |
 | `num_thms`  | `u32`                        | The number of `axiom` and `theorem` in the file.    |
 | `p_terms`   | `p32<[term; num_terms]>`     | The pointer to the [term table](#term-table).       |
-| `p_thms`    | `p64<[thm; num_thms]>`       | The pointer to the [theorem table](#theorem-table). |
+| `p_thms`    | `p32<[thm; num_thms]>`       | The pointer to the [theorem table](#theorem-table). |
 | `p_proof`   | `p32<proof_stream>`          | The pointer to the [proof stream](#proof-stream).   |
 | `reserved2` | `u32`                        | Reserved, should be set to `0`.                     |
 | `p_index`   | `p64<index>`                 | The pointer to the [index](#debugging-index).       |


### PR DESCRIPTION
Typo?
mm0b_parser still shows it [as a U32<LE>](https://github.com/digama0/mm0/blob/b39f1c26f613ec52548c623dd1b5a832bb562894/mm0-rs/components/mm0b_parser/src/lib.rs#L534)