### PR TITLE
fix tutorial instructions

### DIFF
--- a/examples/tutorial/03-mm1-intro.mm1
+++ b/examples/tutorial/03-mm1-intro.mm1
@@ -43,4 +43,4 @@ theorem or_left: $ a -> a \/ b $ = 'absurdr;
 -- * from mm0-c/
 --   run: gcc main.c -o mm0-c
 -- * go back to examples/tutorial/
---   run: ../../mm0-c/mm0-c 03-mm1-intro.mm1 < 03-mm1-intro.mmb
+--   run: ../../mm0-c/mm0-c 03-mm1-intro.mmb < 02-mm0-intro.mm0


### PR DESCRIPTION
The MMB file is the argument to `mm0-c`, and the MM0 file is the
redirected input. (The basename is also different, because it came from
an earlier tutorial step.) `mm0-c` won't parse an MM1 file.