### PR TITLE
Some examples can't be compiled by mm0-rs

### DIFF
--- a/mm0-rs/Cargo.lock
+++ b/mm0-rs/Cargo.lock
@@ -437,6 +437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +673,7 @@ dependencies = [
  "crossbeam",
  "debug_derive",
  "futures",
+ "glob",
  "if_chain",
  "im",
  "instant",

--- a/mm0-rs/Cargo.toml
+++ b/mm0-rs/Cargo.toml
@@ -96,3 +96,6 @@ wasm-bindgen = "0.2"
 name = "mm0-rs"
 path = "src/main.rs"
 doc = false
+
+[dev-dependencies]
+glob = "0.3.0"

--- a/mm0-rs/src/compiler.rs
+++ b/mm0-rs/src/compiler.rs
@@ -55,7 +55,7 @@ enum FileCache {
 }
 
 #[derive(DeepSizeOf, Clone)]
-pub(crate) enum FileContents {
+pub enum FileContents {
   Ascii(Arc<LinedString>),
   #[cfg(not(target_arch = "wasm32"))]
   MMap(Arc<memmap::Mmap>),
@@ -64,23 +64,23 @@ pub(crate) enum FileContents {
 
 impl FileContents {
   /// Constructs a new [`FileContents`] from source text.
-  pub(crate) fn new(text: String) -> Self {
+  pub fn new(text: String) -> Self {
     Self::Ascii(Arc::new(text.into()))
   }
 
   /// Constructs a new [`FileContents`] from a memory map.
   #[cfg(not(target_arch = "wasm32"))]
-  pub(crate) fn new_mmap(data: memmap::Mmap) -> Self {
+  pub fn new_mmap(data: memmap::Mmap) -> Self {
     Self::MMap(Arc::new(data))
   }
 
   /// Constructs a new [`FileContents`] from a memory map.
   #[allow(unused)]
-  pub(crate) fn new_bin(data: Box<[u8]>) -> Self {
+  pub fn new_bin(data: Box<[u8]>) -> Self {
     Self::Bin(data.into())
   }
 
-  pub(crate) fn new_bin_from_file(path: &std::path::Path) -> io::Result<Self> {
+  pub fn new_bin_from_file(path: &std::path::Path) -> io::Result<Self> {
     #[cfg(not(target_arch = "wasm32"))] {
       let file = fs::File::open(path)?;
       // Safety: Well, memory mapping files is never totally safe, but we're assuming
@@ -94,17 +94,17 @@ impl FileContents {
     }
   }
 
-  pub(crate) fn try_ascii(&self) -> Option<&Arc<LinedString>> {
+  pub fn try_ascii(&self) -> Option<&Arc<LinedString>> {
     if let Self::Ascii(e) = self {Some(e)} else {None}
   }
 
   #[track_caller]
-  pub(crate) fn ascii(&self) -> &Arc<LinedString> {
+  pub fn ascii(&self) -> &Arc<LinedString> {
     self.try_ascii().expect("expected ASCII file")
   }
 
   #[allow(unused)]
-  pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+  pub fn ptr_eq(&self, other: &Self) -> bool {
     match (self, other) {
       (Self::Ascii(e1), Self::Ascii(e2)) => Arc::ptr_eq(e1, e2),
       #[cfg(not(target_arch = "wasm32"))]
@@ -469,7 +469,7 @@ fn elaborate_and_send(path: FileRef, send: FSender<ElabResult<()>>, rd: ArcList<
 
 /// Elaborate a file, and return the completed [`FrozenEnv`] result, along with the
 /// file contents.
-pub(crate) fn elab_for_result(path: FileRef) -> io::Result<(FileContents, Option<FrozenEnv>)> {
+pub fn elab_for_result(path: FileRef) -> io::Result<(FileContents, Option<FrozenEnv>)> {
   let (path, file) = VFS.get_or_insert(path)?;
   let env = match block_on(elaborate(path, Default::default()))? {
     ElabResult::Ok(_, _, env) => Some(env),

--- a/mm0-rs/tests/common/mod.rs
+++ b/mm0-rs/tests/common/mod.rs
@@ -1,0 +1,1 @@
+// Common test code goes here

--- a/mm0-rs/tests/integration_test.rs
+++ b/mm0-rs/tests/integration_test.rs
@@ -1,0 +1,13 @@
+mod common;
+
+use mm0_rs::{compiler::elab_for_result, FileRef};
+
+#[test]
+fn elaborate_examples() {
+  for file in glob::glob("../examples/*.mm[01]").unwrap() {
+    let file = file.unwrap();
+    println!("\n--- Elaborating {} ---", file.display());
+    let file_ref = FileRef::from(file);
+    let (_, _) = elab_for_result(file_ref.clone()).expect(&format!("failed to elaborate {}", file_ref.clone()));
+  }
+}


### PR DESCRIPTION
While browsing the examples, I noticed that some of them don't seem to compile with mm0-rs:

```
$ cd mm0-rs; for i in ../examples/*.mm[01]; do cargo run compile "$i" &> /dev/null && echo "    $i" || echo "ERR $i"; done
    ../examples/assembler-new.mm1
    ../examples/assembler-old.mm1
    ../examples/big_unifier.mm1
    ../examples/compiler-new.mm1
    ../examples/compiler-old.mm1
    ../examples/compiler.mm0
    ../examples/compiler.mm1
    ../examples/demo.mm1
    ../examples/do-block.mm1
    ../examples/goldbach.mm0
    ../examples/hello.mm0
    ../examples/hello_assembler.mm0
ERR ../examples/hello_assembler.mm1
    ../examples/hello_mmc.mm1
    ../examples/hol.mm0
    ../examples/hol.mm1
ERR ../examples/lean.mm1
    ../examples/miu.mm0
    ../examples/mm0.mm0
    ../examples/mm0.mm1
    ../examples/peano.mm0
    ../examples/peano.mm1
    ../examples/peano_hex.mm0
    ../examples/peano_hex.mm1
    ../examples/separation_logic.mm1
    ../examples/set.mm0
ERR ../examples/string.mm0
    ../examples/unprovable.mm0
    ../examples/verifier.mm0
ERR ../examples/verifier.mm1
    ../examples/x86.mm0
    ../examples/x86.mm1
    ../examples/x86_determ.mm1
```

I'm attaching a failing integration test for mm0-rs, which tries to elaborate all of the example files. I'm not sure if this is the best way to go about it, or even a good idea at all, but perhaps you find it useful.

Here's the errors I'm getting:

###  `examples/hello_assembler.mm1`

```
thread 'main' panicked at 'SourceAnnotation range `(21432, 21479)` is bigger than source length `0`', /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/annotate-snippets-0.9.1/src/display_list/from_snippet.rs:286:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

###  `examples/lean.mm1`

```
error: regular variables cannot depend on other regular variables
   --> ../examples/lean.mm1:362:53
    |
362 | term iota_epsilon2 (G: ctx) (t F: expr) (L: indspec t)
    |                                                     ^
    |

...
```

###  `examples/string.mm0`

```
error: unsupported input kind
  --> ../examples/string.mm0:28:7
   |
28 | input string: input;
   |       ^^^^^^
   |
```

###  `examples/verifier.mm1`

```
thread 'main' panicked at 'no entry found for key', components/mmcc/src/infer.rs:1002:49
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```