### PR TITLE
Fix MU puzzle axiom catl

### DIFF
--- a/examples/miu.mm0
+++ b/examples/miu.mm0
@@ -26,7 +26,7 @@ term Z: str;
 axiom rfl (a: str): $ a = a $;
 axiom sym (a b: str): $ a = b $ > $ b = a $;
 axiom tr (a b c: str): $ a = b $ > $ b = c $ > $ a = c $;
-axiom catl (a b c: str): $ a = b $ > $ a.b = a.c $;
+axiom catl (a b c: str): $ b = c $ > $ a.b = a.c $;
 axiom catr (a b c: str): $ a = b $ > $ a.c = b.c $;
 axiom zl (a: str): $ Z.a = a $;
 axiom zr (a: str): $ a.Z = a $;


### PR DESCRIPTION
The previous version could be exploited to "solve" the MU puzzle like so: theorem MU: $ M.U $ = '(mp (tr (sym (catl rfl)) (catl rfl)) A0);