### PR TITLE
Update set.mm0

### DIFF
--- a/examples/set.mm0
+++ b/examples/set.mm0
@@ -54,6 +54,9 @@ axiom ax_10 {x: set} (ph: wff x): $ ~(A. x ph) -> A. x ~(A. x ph) $;
 axiom ax_11 {x y: set} (ph: wff x y): $ A. x A. y ph -> A. y A. x ph $;
 axiom ax_12 {x: set} (a: set) (ph: wff x): $ x =s a -> ph -> A. x (x =s a -> ph) $;
 
+def sb (a: set) {x .y: set} (ph: wff x): wff = $ A. y (y =s a -> A. x (x =s y -> ph)) $;
+notation sb (a: set) {x: set} (ph: wff x): wff = ($[$:41) a ($/$:0) x ($]$:0) ph;
+
 axiom ax_ext {x: set} (a b: set): $ A. x (x es. a <-> x es. b) -> a =s b $;
 axiom ax_rep {x y z: set} (a: set) (ph: wff y z):
   $ A. y E. x A. z (ph -> z =s x) ->
@@ -77,7 +80,7 @@ notation cab {x: set} (ph: wff x): class = (${$:max) x ($|$:0) ph ($}$:0);
 
 axiom ax_8b (a b: set) (A: class): $ a =s b -> a ec. A -> b ec. A $;
 
-axiom ax_clab {x: set} (ph: wff x): $ x ec. {x | ph} <-> ph $;
+axiom ax_clab (a: set) {x: set} (ph: wff x): $ a ec. {x | ph} <-> [ a / x ] ph $;
 
 def wceq {.x: set} (A B: class): wff = $ A. x (x ec. A <-> x ec. B) $;
 infixl wceq: $=$ prec 50;

--- a/examples/set.mm0
+++ b/examples/set.mm0
@@ -37,7 +37,7 @@ axiom ax_4 {x: set} (ph ps: wff x): $ A. x (ph -> ps) -> A. x ph -> A. x ps $;
 axiom ax_5 {x: set} (ph: wff): $ ph -> A. x ph $;
 
 term weq (a b: set): wff; infixl weq: $=s$ prec 50;
-term wel (a b: set): wff; infixl wel: $es.$ prec 40;
+term wel (a b: set): wff; infixl wel: $es.$ prec 50;
 
 def weu {x .y: set} (ph: wff x): wff = $ E. y A. x (ph <-> x =s y) $;
 prefix weu: $E!$ prec 30;
@@ -52,7 +52,7 @@ axiom ax_9 (a b c: set): $ a =s b -> c es. a -> c es. b $;
 
 axiom ax_10 {x: set} (ph: wff x): $ ~(A. x ph) -> A. x ~(A. x ph) $;
 axiom ax_11 {x y: set} (ph: wff x y): $ A. x A. y ph -> A. y A. x ph $;
-axiom ax_12 {x y: set} (ph: wff y): $ A. y ph -> A. x (x =s y -> ph) $;
+axiom ax_12 {x: set} (a: set) (ph: wff x): $ x =s a -> ph -> A. x (x =s a -> ph) $;
 
 axiom ax_ext {x: set} (a b: set): $ A. x (x es. a <-> x es. b) -> a =s b $;
 axiom ax_rep {x y z: set} (a: set) (ph: wff y z):

--- a/examples/set.mm0
+++ b/examples/set.mm0
@@ -1,7 +1,7 @@
 delimiter $ ( ) ~ { } $;
 strict provable sort wff;
 term wi (ph ps: wff): wff; infixr wi: $->$ prec 25;
-term wn (ph: wff): wff; prefix wn: $~$ prec 40;
+term wn (ph: wff): wff; prefix wn: $~$ prec 41;
 
 axiom ax_1 (ph ps: wff): $ ph -> ps -> ph $;
 axiom ax_2 (ph ps ch: wff): $ (ph -> ps -> ch) -> (ph -> ps) -> ph -> ch $;
@@ -18,18 +18,22 @@ theorem bi2 (ph ps: wff): $ (ph <-> ps) -> ps -> ph $;
 theorem bi3 (ph ps: wff): $ (ph -> ps) -> (ps -> ph) -> (ph <-> ps) $;
 
 def wa (ph ps: wff): wff = $ ~(ph -> ~ps) $;
-infixl wa: $/\$ prec 20;
+infixl wa: $/\$ prec 34;
 theorem df_an (ph ps: wff): $ (ph /\ ps) <-> ~(ph -> ~ps) $;
+
+def or (ph ps: wff): wff = $ ~ph -> ps $;
+infixl or: $\/$ prec 30;
+theorem df_or (ph ps: wff): $ (ph \/ ps) <-> ~ph -> ps $;
 
 term wtru: wff; prefix wtru: $T.$ prec max;
 axiom tru: $ T. $;
 theorem df_tru (ph: wff): $ T. <-> (ph <-> ph) $;
 
 pure sort set;
-term wal {x: set} (ph: wff x): wff; prefix wal: $A.$ prec 30;
+term wal {x: set} (ph: wff x): wff; prefix wal: $A.$ prec 41;
 
 def wex {x: set} (ph: wff x): wff = $ ~(A. x ~ph) $;
-prefix wex: $E.$ prec 30;
+prefix wex: $E.$ prec 41;
 theorem df_ex {x: set} (ph: wff x): $ E. x ph <-> ~(A. x ~ph) $;
 
 axiom ax_gen {x: set} (ph: wff x): $ ph $ > $ A. x ph $;
@@ -40,7 +44,7 @@ term weq (a b: set): wff; infixl weq: $=s$ prec 50;
 term wel (a b: set): wff; infixl wel: $es.$ prec 50;
 
 def weu {x .y: set} (ph: wff x): wff = $ E. y A. x (ph <-> x =s y) $;
-prefix weu: $E!$ prec 30;
+prefix weu: $E!$ prec 41;
 theorem df_eu {x y: set} (ph: wff x):
   $ E! x ph <-> E. y A. x (ph <-> x =s y) $;
 

--- a/mm0-rs/components/mm0_deepsize/src/lib.rs
+++ b/mm0-rs/components/mm0_deepsize/src/lib.rs
@@ -309,7 +309,9 @@ macro_rules! deep_size_0 {
     };
     (@GO {$($($gen:tt)+)?} $type:ty) => {
         const _: fn() = || {
+            #[allow(dead_code)]
             fn assert_copy<T: ?Sized + Copy>() {}
+            #[allow(dead_code)]
             fn go$(<$($gen)+>)?() {assert_copy::<$type>()}
         };
         $crate::deep_size_0!(@GO {!Copy $($($gen)+)?} $type);

--- a/mm0-rs/components/mm1_parser/src/ast.rs
+++ b/mm0-rs/components/mm1_parser/src/ast.rs
@@ -302,7 +302,7 @@ pub fn curly_transform<T>(
 ) {
   let n = es.len();
   if n > 2 {
-    let valid_curly = no_dot && n % 2 != 0 && {
+    let valid_curly = no_dot && !n.is_multiple_of(2) && {
       let e = &es[1];
       (3..n).step_by(2).all(|i| eq(&es[i], e))
     };

--- a/mm0-rs/src/elab/lisp.rs
+++ b/mm0-rs/src/elab/lisp.rs
@@ -1085,7 +1085,7 @@ str_enum! {
     /// `(- a b)` computes the subtraction `a - b`. `(- a b c)` is `a - b - c`,
     /// `(- a)` is `-a`, and `(-)` is an error.
     Sub: "-",
-    /// {a // b}` computes the integer (flooring) division. More arguments associate to the left.
+    /// `{a // b}` computes the integer (flooring) division. More arguments associate to the left.
     Div: "//",
     /// `{a % b}` computes the integer modulus. More arguments associate to the left.
     Mod: "%",


### PR DESCRIPTION
Fixes #148.

Since I'm here, I also changed ax_12 to match the peano.mm0 version, following the discussion in https://groups.google.com/g/metamath/c/ENg8Hdvlpn4/m/_Nrcn4FuAgAJ.

I also noticed that set.mm0 and peano.mm0 differ on the axiomatization of class abstractions (ax_clab):

set.mm0:
<pre>
strict sort class;
term cab {x: set} (ph: wff x): class;
term welc (a: set) (A: class): wff; infixl welc: $ec.$ prec 50;
notation cab {x: set} (ph: wff x): class = (${$:max) x ($|$:0) ph ($}$:0);

axiom ax_8b (a b: set) (A: class): $ a =s b -> a ec. A -> b ec. A $;

axiom ax_clab {x: set} (ph: wff x): $ x ec. {x | ph} <-> ph $;

def wceq {.x: set} (A B: class): wff = $ A. x (x ec. A <-> x ec. B) $;
infixl wceq: $=$ prec 50;

def cv {.x: set} (a: set): class = $ {x | x es. a} $;
coercion cv: set > class;

def wcel {.x: set} (A B: class): wff = $ E. x (x = A /\ x ec. B) $;
infixl wcel: $e.$ prec 50;
</pre>

peano.mm0:

<pre>

strict sort set;

term ab {x: nat} (p: wff x): set;
notation ab {x: nat} (p: wff x): set = (${$:max) x ($|$:0) p ($}$:0);

term el (a: nat) (A: set): wff; infixl el: $e.$ prec 50;

axiom elab (a: nat) {x: nat} (p: wff x): $ a e. {x | p} <-> [ a / x ] p $;

axiom ax_8 (a b: nat) (A: set): $ a = b -> a e. A -> b e. A $;

def eqs (A B: set) {.x: nat}: wff = $ A. x (x e. A <-> x e. B) $;
infixl eqs: $==$ prec 50;
</pre>

So, should ax_clab in set.mm0 be revised as follows?
<pre>
strict sort class;
term cab {x: set} (ph: wff x): class;
term welc (a: set) (A: class): wff; infixl welc: $ec.$ prec 50;
notation cab {x: set} (ph: wff x): class = (${$:max) x ($|$:0) ph ($}$:0);

axiom ax_8b (a b: set) (A: class): $ a =s b -> a ec. A -> b ec. A $;

axiom ax_clab (a: set) {x: set} (ph: wff x): $ a ec. {x | ph} <-> [ a / x ] ph $;

def wceq {.x: set} (A B: class): wff = $ A. x (x ec. A <-> x ec. B) $;
infixl wceq: $=$ prec 50;

def cv {.x: set} (a: set): class = $ {x | x es. a} $;
coercion cv: set > class;

def wcel {.x: set} (A B: class): wff = $ E. x (x = A /\ x ec. B) $;
infixl wcel: $e.$ prec 50;
</pre>

Such axiomatization would be closer to set.mm as well, and it's the one used in Thierry's version without overloading https://github.com/tirix/set-noov.mm (tho in his database ax_clab is a definition).
