### PR TITLE
Fix null ServerOptions error for helix-editor

### DIFF
--- a/mm0-rs/src/server.rs
+++ b/mm0-rs/src/server.rs
@@ -1827,8 +1827,8 @@ impl Server {
           Ok(Message::Response(resp)) => {
             if resp.id == get_config_id {
               if let Some(val) = resp.result {
-                let [config]: [ServerOptions; 1] = from_value(val)?;
-                *self.options.ulock() = config;
+                let [config]: [Option<ServerOptions>; 1] = from_value(val)?;
+                *self.options.ulock() = config.unwrap_or_default();
               }
             } else {
               let mut caps = caps.ulock();


### PR DESCRIPTION
Fallback to `ServerOptions::default` whenever client responds with `null`.