### PR TITLE
Fix bug where a definition's bound variables were not properly added

### DIFF
--- a/mm0-rs/src/elab/local_context.rs
+++ b/mm0-rs/src/elab/local_context.rs
@@ -551,12 +551,14 @@ impl BuildArgs {
               }
             }
           }
+          let bound_mask = argbv.iter().fold(0, |a, &b| a | b);
           let deps = tdef.ret.1;
           let mut i = 1;
           for arg in argbv {
             if deps & i != 0 { out |= arg }
             i *= 2;
           }
+          out &= !bound_mask;
           out
         } else {unreachable!()},
       _ => unreachable!()

--- a/mm0-rs/src/elab/verify.rs
+++ b/mm0-rs/src/elab/verify.rs
@@ -425,6 +425,8 @@ impl Environment {
             if td.ret.1 & (1 << i) != 0 { accum |= dep }
           }
         }
+        let bound_mask = deps.iter().fold(0, |a, &b| a | b);
+        accum &= !bound_mask;
         (td.ret.0, false, accum)
       }
     })


### PR DESCRIPTION
To be fully honest, I don't know Rust. I used the builtin Github Copilot to VSCode to get this fixed.

I was messing around with MM0 when I tried to use this definition:
`def wtru: wff = $ (A. x (cv x = cv x)) -> (A. x (cv x = cv x)) $;`
This brought up the error "variables {x} missing from dependencies" which didn't make sense. I worked through this with the AI and it suggested this very small edit which appears to have made the error go away.

If the result of this is faulty or breaks some error checking in some way, apologies for the PR. Otherwise, I hope this helps.