### PR TITLE
number of errors in vscode should not disappear when user closes file

### DIFF
--- a/mm0-rs/src/server.rs
+++ b/mm0-rs/src/server.rs
@@ -492,7 +492,8 @@ impl Vfs {
     let mut g = self.0.ulock();
     if let Entry::Occupied(e) = g.entry(path.clone()) {
       if e.get().downstream.ulock().is_empty() {
-        send_diagnostics(path.url().clone(), None, vec![])?;
+        // Diagnostics should be persistent even when the file is closed.
+        // send_diagnostics(path.url().clone(), None, vec![])?;
         e.remove();
       } else if e.get().text.ulock().0.take().is_some() {
         let file = e.get().clone();


### PR DESCRIPTION
suppose I opened a file and mm0-rs showed errors in this file

it shows number of errors in explorer too

but if I close file - then number of errors in explorer disappears

expected - should be persistent bc this is what tsc does